### PR TITLE
Publish pre-built windows binaries using GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Make a release with pre-built executables
+on:
+  push:
+    tags:
+      - '*'
+  # Can also be triggered manually: gh workflow run release.yml --ref Hex2022
+  workflow_dispatch:
+jobs:
+  build-windows-x64:
+    name: Build / Windows x86-64
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: vcpkg cache
+        uses: actions/cache@v4
+        with:
+          path: '~\AppData\Local\vcpkg\archives'
+          key: windows-vcpkg-${{ github.run_id }}
+          restore-keys: |
+            windows-vcpkg-
+      - name: Install dependencies using vcpkg
+        run: |
+          vcpkg install zlib:x64-windows-mixed eigen3:x64-windows-mixed opencl:x64-windows-mixed `
+            --overlay-triplets=ci-files\vcpkg-triplets
+      - name: Build the cmake project (Eigen, 19x19)
+        uses: threeal/cmake-action@main
+        with:
+          source-dir: cpp
+          options: |
+            CMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+            VCPKG_TARGET_TRIPLET=x64-windows-mixed
+            VCPKG_OVERLAY_TRIPLETS=..\ci-files\vcpkg-triplets
+            CMAKE_BUILD_TYPE=Release
+            ZLIB_USE_STATIC_LIBS=TRUE
+            MAX_BOARD_LEN=19
+            USE_BACKEND=EIGEN
+          build-args: --config Release
+      - run: cp cpp/build/Release/katahex.exe katahex-win64-19-eigen.exe && rm cpp/build -r -fo
+      - name: Build the cmake project (OpenCL, 19x19)
+        uses: threeal/cmake-action@main
+        with:
+          source-dir: cpp
+          options: |
+            CMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+            VCPKG_TARGET_TRIPLET=x64-windows-mixed
+            VCPKG_OVERLAY_TRIPLETS=..\ci-files\vcpkg-triplets
+            CMAKE_BUILD_TYPE=Release
+            ZLIB_USE_STATIC_LIBS=TRUE
+            MAX_BOARD_LEN=19
+            USE_BACKEND=OPENCL
+          build-args: --config Release
+      - run: cp cpp/build/Release/katahex.exe katahex-win64-19-opencl.exe && rm cpp/build -r -fo
+      - name: Print checksums
+        run: Get-FileHash -Path .\*.exe -Algorithm SHA256 | Format-List
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: Pre-built KataHex
+          body: |
+            Pre-built binaries for Windows.
+            The opencl one runs on GPU and requires opencl.dll to be installed
+            on the system. This file is usually included with the GPU drivers.
+            The eigen one runs on CPU (built without AVX2 support).
+            The maximum board size is 19x19.
+          files: |
+            katahex-win64-19-eigen.exe
+            katahex-win64-19-opencl.exe

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KataHex   
+# KataHex
 
 KataHex is a Hex engine that is based on Katago. See the original [KataGo README](https://github.com/lightvector/KataGo#readme) for a general information on how it works.
 
@@ -32,6 +32,8 @@ backends below: `-DUSE_BACKEND=CUDA`, `-DUSE_BACKEND=TENSORRT`, or
 By default, the maximum board size is 13x13. To specify a larger
 maximum board size, add something like `-DMAX_BOARD_LEN=19` to the cmake
 call.
+
+For Windows, pre-built KataHex executables are available on the Releases page.
 
 ## Running
 

--- a/ci-files/vcpkg-triplets/x64-windows-mixed.cmake
+++ b/ci-files/vcpkg-triplets/x64-windows-mixed.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+
+if(${PORT} MATCHES "opencl|libzip")
+  set(VCPKG_CRT_LINKAGE dynamic)
+  set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+  set(VCPKG_CRT_LINKAGE static)
+  set(VCPKG_LIBRARY_LINKAGE static)
+endif()


### PR DESCRIPTION
This workflow is activated by pushing a tag (for example, `git tag prebuilt-2024-04-17 && git push --tags`) or by triggering it manually (in the github web interface, or by running `gh workflow run release.yml` using `gh`). It currently creates a draft release, so it must be manually accepted (by editing it) on the releases page to be visible to others.

The included binaries are for windows only, built for `opencl` and `eigen`.

[Example release](https://github.com/Bannerets/kata/releases/tag/prebuilt-2024-04-17)